### PR TITLE
Add `minexponent` axis attribute to control which powers of 10 are displayed with SI prefixes

### DIFF
--- a/src/components/colorbar/attributes.js
+++ b/src/components/colorbar/attributes.js
@@ -173,6 +173,7 @@ module.exports = overrideAll({
     showticksuffix: axesAttrs.showticksuffix,
     separatethousands: axesAttrs.separatethousands,
     exponentformat: axesAttrs.exponentformat,
+    minexponent: axesAttrs.minexponent,
     showexponent: axesAttrs.showexponent,
     title: {
         text: {

--- a/src/components/colorbar/draw.js
+++ b/src/components/colorbar/draw.js
@@ -683,6 +683,7 @@ function mockColorBarAxis(gd, opts, zrange) {
         tickangle: opts.tickangle,
         tickformat: opts.tickformat,
         exponentformat: opts.exponentformat,
+        minexponent: opts.minexponent,
         separatethousands: opts.separatethousands,
         showexponent: opts.showexponent,
         showtickprefix: opts.showtickprefix,

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1042,7 +1042,8 @@ function autoTickRound(ax) {
 
         var maxend = Math.max(Math.abs(rng[0]), Math.abs(rng[1]));
         var rangeexp = Math.floor(Math.log(maxend) / Math.LN10 + 0.01);
-        if(Math.abs(rangeexp) > ax.minexponent) {
+        var minexponent = ax.minexponent === undefined ? 3 : ax.minexponent;
+        if(Math.abs(rangeexp) > minexponent) {
             if(isSIFormat(ax.exponentformat) && !beyondSI(rangeexp)) {
                 ax._tickexponent = 3 * Math.round((rangeexp - 1) / 3);
             } else ax._tickexponent = rangeexp;

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1042,7 +1042,7 @@ function autoTickRound(ax) {
 
         var maxend = Math.max(Math.abs(rng[0]), Math.abs(rng[1]));
         var rangeexp = Math.floor(Math.log(maxend) / Math.LN10 + 0.01);
-        if(Math.abs(rangeexp) > 3) {
+        if(Math.abs(rangeexp) > 3 || ax.exponentformat === 'eng') {
             if(isSIFormat(ax.exponentformat) && !beyondSI(rangeexp)) {
                 ax._tickexponent = 3 * Math.round((rangeexp - 1) / 3);
             } else ax._tickexponent = rangeexp;
@@ -1496,7 +1496,7 @@ function num2frac(num) {
 var SIPREFIXES = ['f', 'p', 'n', 'μ', 'm', '', 'k', 'M', 'G', 'T'];
 
 function isSIFormat(exponentFormat) {
-    return exponentFormat === 'SI' || exponentFormat === 'B';
+    return exponentFormat === 'SI' || exponentFormat === 'B' || exponentFormat === 'eng';
 }
 
 // are we beyond the range of common SI prefixes?

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1042,7 +1042,7 @@ function autoTickRound(ax) {
 
         var maxend = Math.max(Math.abs(rng[0]), Math.abs(rng[1]));
         var rangeexp = Math.floor(Math.log(maxend) / Math.LN10 + 0.01);
-        if(Math.abs(rangeexp) > 3 || ax.exponentformat === 'eng') {
+        if(Math.abs(rangeexp) > ax.minexponent) {
             if(isSIFormat(ax.exponentformat) && !beyondSI(rangeexp)) {
                 ax._tickexponent = 3 * Math.round((rangeexp - 1) / 3);
             } else ax._tickexponent = rangeexp;
@@ -1496,7 +1496,7 @@ function num2frac(num) {
 var SIPREFIXES = ['f', 'p', 'n', 'μ', 'm', '', 'k', 'M', 'G', 'T'];
 
 function isSIFormat(exponentFormat) {
-    return exponentFormat === 'SI' || exponentFormat === 'B' || exponentFormat === 'eng';
+    return exponentFormat === 'SI' || exponentFormat === 'B';
 }
 
 // are we beyond the range of common SI prefixes?
@@ -1525,6 +1525,7 @@ function numFormat(v, ax, fmtoverride, hover) {
         // make a dummy axis obj to get the auto rounding and exponent
         var ah = {
             exponentformat: exponentFormat,
+            minexponent: ax.minexponent,
             dtick: ax.showexponent === 'none' ? ax.dtick :
                 (isNumeric(v) ? Math.abs(v) || 1 : 1),
             // if not showing any exponents, don't change the exponent

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -665,7 +665,7 @@ module.exports = {
     },
     exponentformat: {
         valType: 'enumerated',
-        values: ['none', 'e', 'E', 'power', 'SI', 'B'],
+        values: ['none', 'e', 'E', 'power', 'SI', 'B', 'eng'],
         dflt: 'B',
         role: 'style',
         editType: 'ticks',
@@ -677,7 +677,8 @@ module.exports = {
             'If *E*, 1E+9.',
             'If *power*, 1x10^9 (with 9 in a super script).',
             'If *SI*, 1G.',
-            'If *B*, 1B.'
+            'If *B*, 1B.',
+            '*eng* works like *SI*, except it also uses prefixes for milli- and kilo-.'
         ].join(' ')
     },
     separatethousands: {

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -683,6 +683,7 @@ module.exports = {
     minexponent: {
         valType: 'number',
         dflt: 3,
+        min: 0,
         role: 'style',
         editType: 'ticks',
         description: [

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -687,7 +687,7 @@ module.exports = {
         role: 'style',
         editType: 'ticks',
         description: [
-            'Hide SI prefix for 10^n if |n| is below this number.'
+            'Hide SI prefix for 10^n if |n| is below this number.',
             'This only has an effect when `tickformat` is *SI* or *B*.'
         ].join(' ')
     },

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -665,7 +665,7 @@ module.exports = {
     },
     exponentformat: {
         valType: 'enumerated',
-        values: ['none', 'e', 'E', 'power', 'SI', 'B', 'eng'],
+        values: ['none', 'e', 'E', 'power', 'SI', 'B'],
         dflt: 'B',
         role: 'style',
         editType: 'ticks',
@@ -677,8 +677,16 @@ module.exports = {
             'If *E*, 1E+9.',
             'If *power*, 1x10^9 (with 9 in a super script).',
             'If *SI*, 1G.',
-            'If *B*, 1B.',
-            '*eng* works like *SI*, except it also uses prefixes for milli- and kilo-.'
+            'If *B*, 1B.'
+        ].join(' ')
+    },
+    minexponent: {
+        valType: 'number',
+        dflt: 3,
+        role: 'style',
+        editType: 'ticks',
+        description: [
+            'Hide SI prefix for 10^n if |n| is below this number'
         ].join(' ')
     },
     separatethousands: {

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -687,7 +687,8 @@ module.exports = {
         role: 'style',
         editType: 'ticks',
         description: [
-            'Hide SI prefix for 10^n if |n| is below this number'
+            'Hide SI prefix for 10^n if |n| is below this number.'
+            'This only has an effect when `tickformat` is *SI* or *B*.'
         ].join(' ')
     },
     separatethousands: {

--- a/src/plots/cartesian/tick_label_defaults.js
+++ b/src/plots/cartesian/tick_label_defaults.js
@@ -72,6 +72,7 @@ function handleOtherDefaults(containerIn, containerOut, coerce, axType, options)
             if(!tickFormat && axType !== 'date') {
                 coerce('showexponent', showAttrDflt);
                 coerce('exponentformat');
+                coerce('minexponent');
                 coerce('separatethousands');
             }
         }

--- a/src/plots/gl3d/layout/axis_attributes.js
+++ b/src/plots/gl3d/layout/axis_attributes.js
@@ -108,6 +108,7 @@ module.exports = overrideAll({
     showticksuffix: axesAttrs.showticksuffix,
     showexponent: axesAttrs.showexponent,
     exponentformat: axesAttrs.exponentformat,
+    minexponent: axesAttrs.minexponent,
     separatethousands: axesAttrs.separatethousands,
     tickformat: axesAttrs.tickformat,
     tickformatstops: axesAttrs.tickformatstops,

--- a/src/plots/polar/layout_attributes.js
+++ b/src/plots/polar/layout_attributes.js
@@ -47,6 +47,7 @@ var axisTickAttrs = overrideAll({
     ticksuffix: axesAttrs.ticksuffix,
     showexponent: axesAttrs.showexponent,
     exponentformat: axesAttrs.exponentformat,
+    minexponent: axesAttrs.minexponent,
     separatethousands: axesAttrs.separatethousands,
     tickfont: axesAttrs.tickfont,
     tickangle: axesAttrs.tickangle,

--- a/src/plots/ternary/layout_attributes.js
+++ b/src/plots/ternary/layout_attributes.js
@@ -40,6 +40,7 @@ var ternaryAxesAttrs = {
     ticksuffix: axesAttrs.ticksuffix,
     showexponent: axesAttrs.showexponent,
     exponentformat: axesAttrs.exponentformat,
+    minexponent: axesAttrs.minexponent,
     separatethousands: axesAttrs.separatethousands,
     tickfont: axesAttrs.tickfont,
     tickangle: axesAttrs.tickangle,

--- a/src/traces/carpet/axis_attributes.js
+++ b/src/traces/carpet/axis_attributes.js
@@ -289,7 +289,7 @@ module.exports = {
         dflt: 3,
         min: 0,
         role: 'style',
-        editType: 'ticks',
+        editType: 'calc',
         description: [
             'Hide SI prefix for 10^n if |n| is below this number'
         ].join(' ')

--- a/src/traces/carpet/axis_attributes.js
+++ b/src/traces/carpet/axis_attributes.js
@@ -269,7 +269,7 @@ module.exports = {
     },
     exponentformat: {
         valType: 'enumerated',
-        values: ['none', 'e', 'E', 'power', 'SI', 'B', 'eng'],
+        values: ['none', 'e', 'E', 'power', 'SI', 'B'],
         dflt: 'B',
         role: 'style',
         editType: 'calc',
@@ -281,8 +281,16 @@ module.exports = {
             'If *E*, 1E+9.',
             'If *power*, 1x10^9 (with 9 in a super script).',
             'If *SI*, 1G.',
-            'If *B*, 1B.',
-            '*eng* works like *SI*, except it also uses prefixes for milli- and kilo-.'
+            'If *B*, 1B.'
+        ].join(' ')
+    },
+    minexponent: {
+        valType: 'number',
+        dflt: 3,
+        role: 'style',
+        editType: 'ticks',
+        description: [
+            'Hide SI prefix for 10^n if |n| is below this number'
         ].join(' ')
     },
     separatethousands: {

--- a/src/traces/carpet/axis_attributes.js
+++ b/src/traces/carpet/axis_attributes.js
@@ -287,6 +287,7 @@ module.exports = {
     minexponent: {
         valType: 'number',
         dflt: 3,
+        min: 0,
         role: 'style',
         editType: 'ticks',
         description: [

--- a/src/traces/carpet/axis_attributes.js
+++ b/src/traces/carpet/axis_attributes.js
@@ -269,7 +269,7 @@ module.exports = {
     },
     exponentformat: {
         valType: 'enumerated',
-        values: ['none', 'e', 'E', 'power', 'SI', 'B'],
+        values: ['none', 'e', 'E', 'power', 'SI', 'B', 'eng'],
         dflt: 'B',
         role: 'style',
         editType: 'calc',
@@ -281,7 +281,8 @@ module.exports = {
             'If *E*, 1E+9.',
             'If *power*, 1x10^9 (with 9 in a super script).',
             'If *SI*, 1G.',
-            'If *B*, 1B.'
+            'If *B*, 1B.',
+            '*eng* works like *SI*, except it also uses prefixes for milli- and kilo-.'
         ].join(' ')
     },
     separatethousands: {

--- a/src/traces/carpet/axis_defaults.js
+++ b/src/traces/carpet/axis_defaults.js
@@ -78,6 +78,7 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, options)
     coerce('separatethousands');
     coerce('tickformat');
     coerce('exponentformat');
+    coerce('minexponent');
     coerce('showexponent');
     coerce('categoryorder');
 
@@ -186,6 +187,7 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, options)
         delete containerOut.tickangle;
         delete containerOut.showexponent;
         delete containerOut.exponentformat;
+        delete containerOut.minexponent;
         delete containerOut.tickformat;
         delete containerOut.showticksuffix;
         delete containerOut.showtickprefix;

--- a/src/traces/indicator/attributes.js
+++ b/src/traces/indicator/attributes.js
@@ -355,6 +355,7 @@ module.exports = {
             showticksuffix: axesAttrs.showticksuffix,
             separatethousands: axesAttrs.separatethousands,
             exponentformat: axesAttrs.exponentformat,
+            minexponent: axesAttrs.minexponent,
             showexponent: axesAttrs.showexponent,
             editType: 'plot'
         }, 'plot'),

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2722,6 +2722,7 @@ describe('Test axes', function() {
 
     describe('calcTicks and tickText', function() {
         function mockCalc(ax) {
+            ax = {minexponent: 3, ...ax};
             ax.tickfont = {};
             Axes.setConvert(ax, {separators: '.,', _extraFormat: {
                 year: '%Y',

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2876,7 +2876,8 @@ describe('Test axes', function() {
                 '10<sup>17</sup>',
                 '10<sup>18</sup>'
             ]);
-            var textOut = mockCalc({
+
+            textOut = mockCalc({
                 type: 'log',
                 tickmode: 'linear',
                 exponentformat: 'SI',

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2722,7 +2722,8 @@ describe('Test axes', function() {
 
     describe('calcTicks and tickText', function() {
         function mockCalc(ax) {
-            ax = Object.assign({minexponent: 3}, ax);
+            if (ax.minexponent === undefined)
+                ax.minexponent = 3;
             ax.tickfont = {};
             Axes.setConvert(ax, {separators: '.,', _extraFormat: {
                 year: '%Y',

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2851,6 +2851,57 @@ describe('Test axes', function() {
             ]);
         });
 
+        it('Does not use SI prefixes for 10^n with |n| < minexponent', function() {
+            var textOut = mockCalc({
+                type: 'log',
+                tickmode: 'linear',
+                exponentformat: 'SI',
+                minexponent: 5,
+                showexponent: 'all',
+                tick0: 0,
+                dtick: 1,
+                range: [-18.5, 18.5]
+            });
+
+            expect(textOut).toEqual([
+                '10<sup>\u221218</sup>',
+                '10<sup>\u221217</sup>',
+                '10<sup>\u221216</sup>',
+                '1f', '10f', '100f', '1p', '10p', '100p', '1n', '10n', '100n',
+                '1μ', '0.00001', '0.0001', '0.001', '0.01', '0.1', '1', '10', '100',
+                '1000', '10,000', '100,000', '1M', '10M', '100M', '1G', '10G', '100G',
+                '1T', '10T', '100T',
+                '10<sup>15</sup>',
+                '10<sup>16</sup>',
+                '10<sup>17</sup>',
+                '10<sup>18</sup>'
+            ]);
+            var textOut = mockCalc({
+                type: 'log',
+                tickmode: 'linear',
+                exponentformat: 'SI',
+                minexponent: 0,
+                showexponent: 'all',
+                tick0: 0,
+                dtick: 1,
+                range: [-18.5, 18.5]
+            });
+
+            expect(textOut).toEqual([
+                '10<sup>\u221218</sup>',
+                '10<sup>\u221217</sup>',
+                '10<sup>\u221216</sup>',
+                '1f', '10f', '100f', '1p', '10p', '100p', '1n', '10n', '100n',
+                '1μ', '10μ', '100μ', '1m', '10m', '100m', '1', '10', '100',
+                '1k', '10k', '100k', '1M', '10M', '100M', '1G', '10G', '100G',
+                '1T', '10T', '100T',
+                '10<sup>15</sup>',
+                '10<sup>16</sup>',
+                '10<sup>17</sup>',
+                '10<sup>18</sup>'
+            ]);
+        });
+
         it('supports e/E format on log axes', function() {
             ['e', 'E'].forEach(function(e) {
                 var textOut = mockCalc({

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2722,8 +2722,9 @@ describe('Test axes', function() {
 
     describe('calcTicks and tickText', function() {
         function mockCalc(ax) {
-            if (ax.minexponent === undefined)
+            if(ax.minexponent === undefined) {
                 ax.minexponent = 3;
+            }
             ax.tickfont = {};
             Axes.setConvert(ax, {separators: '.,', _extraFormat: {
                 year: '%Y',

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2722,7 +2722,7 @@ describe('Test axes', function() {
 
     describe('calcTicks and tickText', function() {
         function mockCalc(ax) {
-            ax = {minexponent: 3, ...ax};
+            ax = Object.assign({minexponent: 3}, ax);
             ax.tickfont = {};
             Axes.setConvert(ax, {separators: '.,', _extraFormat: {
                 year: '%Y',

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2722,9 +2722,6 @@ describe('Test axes', function() {
 
     describe('calcTicks and tickText', function() {
         function mockCalc(ax) {
-            if(ax.minexponent === undefined) {
-                ax.minexponent = 3;
-            }
             ax.tickfont = {};
             Axes.setConvert(ax, {separators: '.,', _extraFormat: {
                 year: '%Y',


### PR DESCRIPTION
Works just like `SI`, except it uses the kilo prefix for 1000 and uses the milli prefix (which `SI` doesn't).

# Existing `SI`:

![image](https://user-images.githubusercontent.com/408363/91469994-855f1580-e86a-11ea-9ac5-8a1e4410d743.png)
![image](https://user-images.githubusercontent.com/408363/91469928-6d879180-e86a-11ea-9fa2-2f521b04f3a3.png)
![image](https://user-images.githubusercontent.com/408363/91470128-b2abc380-e86a-11ea-80a2-0f31fdc9a196.png)

# New `eng`

![image](https://user-images.githubusercontent.com/408363/91469599-f81bc100-e869-11ea-975a-7d1580abf787.png)
![image](https://user-images.githubusercontent.com/408363/91469813-48931e80-e86a-11ea-9251-28d104c99f6f.png)
![image](https://user-images.githubusercontent.com/408363/91470441-1930e180-e86b-11ea-8db2-0b8e8b4e3587.png)
